### PR TITLE
specified in environment.yml sphinx book theme to use

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,5 +10,6 @@ dependencies:
   - matplotlib
   - pip=20
   - pip:
-    - jupyter-book
+    - jupyter-book==0.7.1
+    - sphinx-book-theme==0.0.30
     - ghp-import


### PR DESCRIPTION
This follows on from your troubleshooting last week regarding the collapsible headings on TOC.

It seems as if Jupyter Books can't handle sections greater than 3 layers deep (https://jupyterbook.org/customize/toc.html#files) which is why we're having so much trouble with the Ansys Fluent/Chemkin/CFX. 

This PR only updates the `environment.yml` to include hard versions for sphinx-book-theme and jupyter-book to ensure collapsible sections is the default behaviour for the TOC.

I would suggest that in this example the links on the Ansys page are enough to then direct users to more specific instructions for Fluent/Chemkin/CFX, but this is a point for discussion.