### PR TITLE
removing python-version from workflow

### DIFF
--- a/.github/workflows/buildbook.yml
+++ b/.github/workflows/buildbook.yml
@@ -17,7 +17,6 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml
-        python-version: 3.8
         auto-activate-base: false
         activate-environment: arcdocs-jb
 


### PR DESCRIPTION
removing python-version should prevent errors in the setup-miniconda action after recent changes