### PR TITLE
adding a test build action resolving #57

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -2,13 +2,13 @@
 
 name: test-build
 
-# Only run this when the master branch changes
+# Only run this when a PR suggests changes to working-master
 on:
   pull_request:
     branches:
       - working-master
 
-# This job installs dependencies, build the book, and pushes it to `gh-pages`
+# This job installs dependencies and builds the book
 jobs:
   deploy-book:
     runs-on: ubuntu-latest

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -1,0 +1,29 @@
+# copied from https://jupyterbook.org/publish/gh-pages.html?highlight=github%20pages
+
+name: test-build
+
+# Only run this when the master branch changes
+on:
+  pull_request:
+    branches:
+      - working-master
+
+# This job installs dependencies, build the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        environment-file: environment.yml
+        auto-activate-base: false
+        activate-environment: arcdocs-jb
+
+    # Build the book
+    - name: Build the book
+      shell: bash -l {0}
+      run: |
+        conda activate arcdocs-jb
+        jupyter-book build ./book/
+


### PR DESCRIPTION
This PR introduces a new CI action that just builds the jupyter book on any pull requests onto `working-master`. 

This is a simple check to ensure the book builds before merging. I've not quite worked out how to configure it to tell us about any warnings generated during the build step, but we can look at adding that down the line (once i've worked it out!).