### PR TITLE
single line update for ProxyCommand instructions

### DIFF
--- a/book/getting_started/logon.md
+++ b/book/getting_started/logon.md
@@ -76,7 +76,7 @@ In order to connect to ARC when you're off campus you'll need to do some extra c
 
     ```
     Host *.leeds.ac.uk !remote-access.leeds.ac.uk
-    ProxyCommand ssh -W %h:%p USERNAME@remote-access.leeds.ac.uk
+    ProxyCommand ssh -o PreferredAuthentications=keyboard-interactive -W %h:%p USERNAME@remote-access.leeds.ac.uk
     User USERNAME
     ```
     ````


### PR DESCRIPTION
our previous instructions for ProxyCommand usage don't work with 2FA, updated to specify option of keyboard-interactive auth