### PR TITLE
Docs: adding guidance examples

### DIFF
--- a/book/guidance/data_management.md
+++ b/book/guidance/data_management.md
@@ -152,3 +152,27 @@ This guide asks a range of questions to consider when planning your data managem
 - [Individual Rights (Data Protection)](https://dataprotection.leeds.ac.uk/individual-rights/)
 - [Reporting a Data Security Incident (Data Protection)](https://dataprotection.leeds.ac.uk/reporting-a-data-security-incident/)
 - [Further information (The Turing Way)](https://the-turing-way.netlify.app/reproducible-research/rdm/rdm-dmp.html#further-reading-recommendations)
+
+## Examples
+
+```{admonition} PhD: ...
+
+- Data handling
+  - ...
+- The data management plan
+  - ...
+- Personal data
+  - ...
+
+```
+
+```{admonition} Fellowship: ...
+
+- Data handling
+  - ...
+- The data management plan
+  - ...
+- Personal data
+  - ...
+
+```

--- a/book/guidance/data_management.md
+++ b/book/guidance/data_management.md
@@ -157,4 +157,4 @@ This guide asks a range of questions to consider when planning your data managem
 
 - [DMPOnline](https://dmponline.dcc.ac.uk/public_plans)
 - [Published DMPs](https://riojournal.com/browse_journal_articles.php?section_type%5B%5D=231)
-- [Digital Curation Centre](http://www.dcc.ac.uk/resources/data-management-plans/guidance-examples)
+- [Digital Curation Centre](https://www.dcc.ac.uk/resources/data-management-plans/guidance-examples)

--- a/book/guidance/data_management.md
+++ b/book/guidance/data_management.md
@@ -155,24 +155,6 @@ This guide asks a range of questions to consider when planning your data managem
 
 ## Examples
 
-```{admonition} PhD: ...
-
-- Data handling
-  - ...
-- The data management plan
-  - ...
-- Personal data
-  - ...
-
-```
-
-```{admonition} Fellowship: ...
-
-- Data handling
-  - ...
-- The data management plan
-  - ...
-- Personal data
-  - ...
-
-```
+- [DMPOnline](https://dmponline.dcc.ac.uk/public_plans)
+- [Published DMPs](https://riojournal.com/browse_journal_articles.php?section_type%5B%5D=231)
+- [Digital Curation Centre](http://www.dcc.ac.uk/resources/data-management-plans/guidance-examples)

--- a/book/guidance/software_management.md
+++ b/book/guidance/software_management.md
@@ -130,36 +130,36 @@ _Examples are not an exhaustive list of possible options and many are Python-spe
 
 ## Examples
 
-```{admonition} [PhD: Medical Statistics](https://the-turing-way.netlify.app/reproducible-research/case-studies/case-study-statistical.html)
-
-- Version control
-  - [GitHub](https://github.com/kkmann/sample-size-calculation-under-uncertainty)
-  - Continuous integration with [GitHub Actions](https://github.com/kkmann/sample-size-calculation-under-uncertainty/actions)
-- Capture project environment
-  - Docker (using with [repo2docker](https://github.com/jupyterhub/repo2docker))
-- Share project environment
-  - Citable DOI through [Zenodo](https://zenodo.org/record/4293865)
-  - [MIT license](https://github.com/kkmann/sample-size-calculation-under-uncertainty/blob/master/LICENSE)
-  - Recreate the results using [BinderHub](https://mybinder.org/v2/gh/kkmann/sample-size-calculation-under-uncertainty/master?urlpath=lab/tree/sample-size-calculation-under-uncertainty.ipynb) 
-  - Interact with the results using a [Shiny app](https://mybinder.org/v2/gh/kkmann/sample-size-calculation-under-uncertainty/master?urlpath=shiny/shiny-app/)
-- Tests
-  - Unknown
-- Documentation
-  - Unknown
-
-```
-
-```{admonition} Fellowship: ...
-
-- Version control
-  - ...
-- Capture project environment
-  - ...
-- Share project environment
-  - ...
-- Tests
-  - ...
-- Documentation
-  - ...
-
-```
+- [SHAP (SHapley Additive exPlanations)](https://github.com/slundberg/shap)
+    - Version control with GitHub
+    - Continuous integration with GitHub Actions, Travis CI
+    - Capture and share project environment via conda or pip
+    - MIT license
+    - Documentation with examples
+    - Tests with pytest
+    - Reproducible via Binder
+- [TPOT (Tree-based Pipeline Optimization Tool)](https://github.com/EpistasisLab/tpot)
+    - Version control with GitHub
+    - Continuous integration with GitHub Actions, Travis CI, AppVeyor
+    - Capture and share project environment via conda or pip
+    - LGPL-3.0 license
+    - Documentation with examples
+    - Tests with pytest
+    - Citable DOI through Zenodo
+    - Code coverage with Coveralls
+- [PyHealth (A Python Library for Health Predictive Models)](https://github.com/zzachw/PyHealth)
+    - Version control with GitHub
+    - Continuous integration with Circle CI, Travis CI, AppVeyor
+    - Capture and share project environment via pip
+    - BSD-2-Clause license
+    - Documentation with examples
+    - Tests with pytest
+    - Reproducible via Binder
+- [VEROS (versatile ocean simulator Python / JAX)](https://github.com/team-ocean/veros)
+    - Version control with GitHub
+    - Continuous integration with GitHub Actions
+    - Capture and share project environment via conda or pip
+    - MIT license
+    - Documentation with examples
+    - Tests with pytest
+    - Code coverage with codecov

--- a/book/guidance/software_management.md
+++ b/book/guidance/software_management.md
@@ -124,3 +124,39 @@ _Examples are not an exhaustive list of possible options and many are Python-spe
 - [CodeRefinery](https://coderefinery.org/)
 - [UK Reproducibility Network](https://www.ukrn.org/)
 - [Versioning (UK Data Service)](https://ukdataservice.ac.uk/learning-hub/research-data-management/format-your-data/versioning/)
+
+## Examples
+
+```{admonition} [PhD: Medical Statistics](https://the-turing-way.netlify.app/reproducible-research/case-studies/case-study-statistical.html)
+
+- Version control
+  - [GitHub](https://github.com/kkmann/sample-size-calculation-under-uncertainty)
+  - Continuous integration with [GitHub Actions](https://github.com/kkmann/sample-size-calculation-under-uncertainty/actions)
+- Capture project environment
+  - Docker (using with [repo2docker](https://github.com/jupyterhub/repo2docker))
+- Share project environment
+  - Citable DOI through [Zenodo](https://zenodo.org/record/4293865)
+  - [MIT license](https://github.com/kkmann/sample-size-calculation-under-uncertainty/blob/master/LICENSE)
+  - Recreate the results using [BinderHub](https://mybinder.org/v2/gh/kkmann/sample-size-calculation-under-uncertainty/master?urlpath=lab/tree/sample-size-calculation-under-uncertainty.ipynb) 
+  - Interact with the results using a [Shiny app](https://mybinder.org/v2/gh/kkmann/sample-size-calculation-under-uncertainty/master?urlpath=shiny/shiny-app/)
+- Tests
+  - Unknown
+- Documentation
+  - Unknown
+
+```
+
+```{admonition} Fellowship: ...
+
+- Version control
+  - ...
+- Capture project environment
+  - ...
+- Share project environment
+  - ...
+- Tests
+  - ...
+- Documentation
+  - ...
+
+```


### PR DESCRIPTION
### Summary
Adding examples to the guidance documents.

### Changes
- [x] `book/guidance/data_management.md`: Adding examples.
- [x] `book/guidance/software_management.md`: Adding example.