### PR TITLE
add link to CEMAC CESM page to software/applications

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -53,6 +53,7 @@
         - file: software/applications/ansys/cfx
         - file: software/applications/ansys/fluent
         - file: software/applications/ansys/chemkin
+      - file: software/applications/cesm
       - file: software/applications/comsol
       - file: software/applications/dl_poly
         sections:

--- a/book/software/applications/cesm.md
+++ b/book/software/applications/cesm.md
@@ -1,0 +1,15 @@
+# CESM
+
+```{note}
+This page relates to a community maintained module and is not directly supported by the Research Computing Team
+```
+
+The Community Earth System Model ([CESM](https://www.cesm.ucar.edu/)) is a coupled climate model. It has seven different components: atmosphere, ocean, river run off, sea ice, land ice. The Common Infrastructure for Modeling the Earth (CIME) is a python based tool for coupling these different aspects together. The latest release is CESM 2.1.3 using CIME 5.6.
+
+- [ARC4 CESM Documentation](https://cesm2-arc4-rtd.readthedocs.io/en/latest/index.html)
+
+[CEMAC](https://www.cemac.leeds.ac.uk/) has ported CESM2.1.3 to ARC4 and maintains the linked documentation and the CESM directory on ARC4. 
+
+To begin using CESM on ARC4, or to get help, please contact the CEMAC support.
+
+Email: [cemac-support@leeds.ac.uk](mailto:cemac-support@leeds.ac.uk)

--- a/book/software/applications/cesm.md
+++ b/book/software/applications/cesm.md
@@ -4,7 +4,7 @@
 This page relates to a community maintained module and is not directly supported by the Research Computing Team
 ```
 
-The Community Earth System Model ([CESM](https://www.cesm.ucar.edu/)) is a coupled climate model. It has seven different components: atmosphere, ocean, river run off, sea ice, land ice. The Common Infrastructure for Modeling the Earth (CIME) is a python based tool for coupling these different aspects together. The latest release is CESM 2.1.3 using CIME 5.6.
+The Community Earth System Model ([CESM](https://www.cesm.ucar.edu/)) is a coupled climate model. It has several different components: atmosphere, ocean, river run off, sea ice, land ice. The Common Infrastructure for Modeling the Earth (CIME) is a python based tool for coupling these different aspects together. The latest release is CESM 2.1.3 using CIME 5.6.
 
 - [ARC4 CESM Documentation](https://cesm2-arc4-rtd.readthedocs.io/en/latest/index.html)
 

--- a/book/software/applications/start.md
+++ b/book/software/applications/start.md
@@ -7,6 +7,7 @@ This page is an overview of the applications section of software available on th
 - [Abaqus](./abaqus)
 - [Amber](./amber)
 - [Ansys](./ansys.md)
+- [CESM](./cesm)
 - [Comsol](./comsol)
 - [DL_POLY](./dl_poly)
 - [Gaussian](./gaussian)


### PR DESCRIPTION
This small PR adds a CESM entry to our applications list and links to the CEMAC supported CESM ARC4 installation docs.