### PR TITLE
Adding recommended courses

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -188,6 +188,7 @@
     - file: guidance/software_management
     - file: guidance/software_licensing
     - file: guidance/recommended_platforms
+    - file: guidance/recommended_courses
 
 # ===== Training ==========================================
 - url: https://arc.leeds.ac.uk/training/

--- a/book/guidance/recommended_courses.md
+++ b/book/guidance/recommended_courses.md
@@ -40,7 +40,7 @@ They are useful complements to your studies and the various [Training Courses](h
 
 - [Composing Programs](https://composingprograms.com/), John DeNero, 61A course, UC Berkeley.
     - [Video lectures](https://www.youtube.com/c/JohnDeNero/playlists).
-- [Python Distilled](http://www.dabeaz.com/python-distilled/), David Beazley, 2021.
+- [Python Distilled](https://www.dabeaz.com/python-distilled/), David Beazley, 2021.
     - [Course](https://dabeaz-course.github.io/practical-python/)
 
 (algorithms_and_data_structure)=
@@ -118,7 +118,7 @@ They are useful complements to your studies and the various [Training Courses](h
 
 - [Deep Learning Specialization](https://www.coursera.org/specializations/deep-learning), Coursera, [DeepLearning.AI](https://deeplearning.ai/).
     - [Video lectures](https://www.youtube.com/playlist?list=PLoROMvodv4rOABXSygHTsbvUz4G_YQhOb), CS230, Stanford University.
-    - [Syllabus](http://cs230.stanford.edu/syllabus/), CS230, Stanford University.
+    - [Syllabus](https://cs230.stanford.edu/syllabus/), CS230, Stanford University.
 - [NYU Deep Learning](https://atcold.github.io/NYU-DLSP21/), Yann LeCun and Alfredo Canziani, NYU, 2021.
     - [Video lectures](https://www.youtube.com/playlist?list=PLLHTzKZzVU9e6xUfG10TkTWApKSZCzuBI).
     

--- a/book/guidance/recommended_courses.md
+++ b/book/guidance/recommended_courses.md
@@ -1,0 +1,150 @@
+# Recommended Courses
+
+Here are some recommended online courses for various topics in research computing.  
+
+They are useful complements to your studies and the various [Training Courses](https://arc.leeds.ac.uk/training/) we provide here.
+
+## Contents
+
+- [Software Engineering](software_engineering)
+    - [Programming](programming)
+        - [Python](python)
+    - [Algorithms and Data Structures](algorithms_and_data_structure)
+    - [Distributed Systems](distributed_systems)
+    - [Cloud Computing](cloud_computing)
+    - [Testing](testing)
+    - [Research Software Engineering](research_software_engineering)
+    - [Packaging](packaging)
+    - [Version Control](version_control)
+- [Data Science](data_science)
+    - [Foundations](foundations)
+    - [Causal Inference](causal_inference)
+    - [Applied Maths](applied_maths)
+- [Machine Learning](machine_learning_section)
+    - [Machine Learning](machine_learning_content)
+    - [Deep Learning](deep_learning)
+    - [Maths for Machine Learning](maths_for_machine_learning)
+    - [MLOps](mlops)
+    - [Applications](applications)
+- [Numerical Modelling](numerical_modelling)
+    - [Weather and Climate](weather_and_climate)
+    
+(software_engineering)=
+## Software Engineering
+
+(programming)=
+### Programming
+
+(python)=
+#### Python
+
+- [Composing Programs](https://composingprograms.com/), John DeNero, 61A course, UC Berkeley.
+    - [Video lectures](https://www.youtube.com/c/JohnDeNero/playlists).
+- [Python Distilled](http://www.dabeaz.com/python-distilled/), David Beazley, 2021.
+    - [Course](https://dabeaz-course.github.io/practical-python/)
+
+(algorithms_and_data_structure)=
+### Algorithms and Data Structures
+
+- [Introduction to Algorithms](https://youtube.com/playlist?list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb), Srini Devadas and Erik Demaine, MIT 6.006, 2011.
+
+(distributed_systems)=
+### Distributed Systems
+
+- [Distributed Systems](https://www.youtube.com/playlist?list=PLrw6a1wE39_tb2fErI4-WkMbsvGQk9_UB), MIT 6.824, Robert Morris, 2020.
+
+(cloud_computing)=
+### Cloud Computing
+
+- [Microsoft Azure Fundamentals (AZ-900)](https://www.youtube.com/playlist?list=PLGjZwEtPN7j-Q59JYso3L4_yoCjj2syrM), Adam Marczak.
+
+(testing)=
+### Testing
+
+- [Software Testing Fundamentals](https://softwaretestingfundamentals.com/)
+
+(research_software_engineering)=
+### Research Software Engineering
+
+- [Research Software Engineering with Python](https://alan-turing-institute.github.io/rse-course/html/index.html), The Alan Turing Institute.
+
+(packaging)=
+### Packaging
+
+- [Python Packages](https://py-pkgs.org/), Tomas Beuzen & Tiffany Timbers, 2021.
+
+(version_control)=
+### Version Control
+
+- [First Week on GitHub](https://lab.github.com/githubtraining/first-week-on-github), GitHub Learning Lab.
+
+(data_science)=
+## Data Science
+
+(foundations)=
+### Foundations
+
+- [Computational and Inferential Thinking: The Foundations of Data Science](https://inferentialthinking.com/chapters/intro.html), Data 8: Foundations of Data Science course, UC Berkeley.
+    - [Video lectures](https://www.youtube.com/playlist?list=PL3juAj0fqNsI4HLvMJFnZDDabxAExG0wv).
+- [The Turing Way Handbook of Data Science](https://the-turing-way.netlify.app/welcome.html)
+
+(causal_inference)=
+### Causal Inference
+
+- [Causal Diagrams: Draw Your Assumptions Before Your Conclusions](https://www.edx.org/course/causal-diagrams-draw-your-assumptions-before-your), Miguel Hernan, Harvard University.
+- [Introduction to Causal Inference](https://www.bradyneal.com/causal-inference-course), Brady Neal.
+    - [Video lectures](https://www.youtube.com/playlist?list=PLoazKTcS0RzZ1SUgeOgc6SWt51gfT80N0).
+
+(applied_maths)=
+### Applied Maths
+
+- [Engineering Mathematics (ME564 and ME565)](https://www.youtube.com/playlist?list=PLMrJAkhIeNNR2W2sPWsYxfrxcASrUt_9j), Steve Brunton, University of Washington.
+
+(machine_learning_section)=
+## Machine Learning
+
+(machine_learning_content)=
+### Machine Learning
+
+- [Machine learning](https://www.coursera.org/learn/machine-learning), Coursera, Andrew Ng.
+    - [Video lectures](https://www.youtube.com/playlist?list=PLoROMvodv4rMiGQp3WXShtMGgzqpfVfbU), CS229, Standford University.
+- [Machine Learning for Intelligent Systems](https://www.cs.cornell.edu/courses/cs4780/2018fa/lectures/), Kilian Weinberger, 2018.
+    - CS4780, Cornell: [Video lectures](https://youtube.com/playlist?list=PLl8OlHZGYOQ7bkVbuRthEsaLr7bONzbXS).
+- [Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow, 2nd Edition](https://www.oreilly.com/library/view/hands-on-machine-learning/9781492032632/), Aurélien Géron, 2019, O’Reilly Media, Inc.
+    - [Jupyter Notebooks](https://github.com/ageron/handson-ml2)
+
+(deep_learning)=
+### Deep Learning
+
+- [Deep Learning Specialization](https://www.coursera.org/specializations/deep-learning), Coursera, [DeepLearning.AI](https://deeplearning.ai/).
+    - [Video lectures](https://www.youtube.com/playlist?list=PLoROMvodv4rOABXSygHTsbvUz4G_YQhOb), CS230, Stanford University.
+    - [Syllabus](http://cs230.stanford.edu/syllabus/), CS230, Stanford University.
+- [NYU Deep Learning](https://atcold.github.io/NYU-DLSP21/), Yann LeCun and Alfredo Canziani, NYU, 2021.
+    - [Video lectures](https://www.youtube.com/playlist?list=PLLHTzKZzVU9e6xUfG10TkTWApKSZCzuBI).
+    
+(maths_for_machine_learning)=
+### Maths for Machine Learning
+
+- [Linear Algebra](https://www.youtube.com/playlist?list=PLE7DDD91010BC51F8), Gilbert Strang, MIT 18.06, 2005.
+- [Essence of linear algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab), 3Blue1Brown.
+- [Essence of calculus](https://www.youtube.com/playlist?list=PLZHQObOWTQDMsr9K-rj53DwVRMYO3t5Yr), 3Blue1Brown.
+- [Matrix Methods in Data Analysis, Signal Processing, and Machine Learning](https://www.youtube.com/playlist?list=PLUl4u3cNGP63oMNUHXqIUcrkS2PivhN3k), Gilbert Strang, MIT 18.065, 2018.
+
+(mlops)=
+### MLOps
+
+- [Machine Learning Engineering for Production (MLOps) Specialization](https://www.coursera.org/specializations/machine-learning-engineering-for-production-mlops?utm_source=deeplearning-ai&utm_medium=institutions&utm_campaign=20210423-mlep-1-deeplearning-ai-institutions-dlai-website), Coursera, [DeepLearning.AI](https://deeplearning.ai/).
+
+(applications)=
+### Applications
+
+- [Machine Learning for Healthcare](https://www.youtube.com/playlist?list=PLUl4u3cNGP60B0PQXVQyGNdCyCTDU1Q5j), MIT 6.S897, David Sontag and Peter Szolovits, 2019.
+
+(numerical_modelling)=
+## Numerical Modelling
+
+(weather_and_climate)=
+### Weather and Climate
+
+- [Art of Climate Modeling](https://www.youtube.com/playlist?list=PL_cuIb7hx5lihu3Wq605u6kVGltXgEfDt), Paul Ullrich, UC Davis.
+


### PR DESCRIPTION
Here is a first pass at a recommended courses page.

The purpose is to list high-quality courses and resources in research computing. Ideally, ones that you've taken and would recommend.

It currently includes various topics grouped into software engineering, data science, machine learning, and numerical modelling. 

The idea is to continually expand / improve on these.

There are many areas that require recommendations (e.g., Linux, R, C++, Fortran, Julia, HPC, Computer Architecture, Databases). And there's probably many more that I've missed. I've added these as a reminder issue here, which we can incrementally add in the future.