### PR TITLE
Pin to known working version of Jinja2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
 dependencies:
   - python=3.7.6
+  - jinja2=3.0.3
   - pip=20
   - pip:
     - jupyter-book==0.9.1


### PR DESCRIPTION
Minimal fix to use an existing version of Jinja2, not the recently released one.