### PR TITLE
Change absolute URLs to internal references

### DIFF
--- a/book/guidance/recommended_platforms.md
+++ b/book/guidance/recommended_platforms.md
@@ -13,10 +13,10 @@ This guide asks a range of questions to consider when deciding which platform to
 - For example, a local laptop / workstation may have 4-64 GB
 - There may be tools and methods to reduce memory usage, e.g., [SWD6: High Performance Python](https://arc.leeds.ac.uk/training/courses/swd6/)
 - High Performance Computers (HPC)
-  - [ARC3](https://arcdocs.leeds.ac.uk/systems/arc3.html#standard-nodes)
+  - [ARC3](../systems/arc3.html#standard-nodes)
     - Standard 128 GB
     - High-memory 768 GB
-  - [ARC4](https://arcdocs.leeds.ac.uk/systems/arc4.html#standard-nodes)
+  - [ARC4](../systems/arc4.html#standard-nodes)
     - Standard 192 GB
     - High-memory 768 GB
 - Cloud computing
@@ -30,19 +30,19 @@ This guide asks a range of questions to consider when deciding which platform to
   - 5 TB each, for all users
   - Quota increase is available on request to IT services
 - HPC
-  - [ARC3](https://arcdocs.leeds.ac.uk/systems/arc3.html#lustre-storage)
+  - [ARC3](../systems/arc3.html#lustre-storage)
     - 836 TB Lustre storage, at 4GB/s (/nobackup)
-  - [ARC4](https://arcdocs.leeds.ac.uk/systems/arc4.html#lustre-storage)
+  - [ARC4](../systems/arc4.html#lustre-storage)
     - 1.2 PB Lustre storage, at 11GB/s (/nobackup)
 
 ### Do you need to parallelise the work over many cores?
 
 - For example, a local laptop / workstation may have 4-16 cores
 - HPC
-  - [ARC3](https://arcdocs.leeds.ac.uk/systems/arc3.html#standard-nodes)
+  - [ARC3](../systems/arc3.html#standard-nodes)
     - 252 standard nodes, each with 24 cores
     - 4 high-memory nodes, each with 24 cores
-  - [ARC4](https://arcdocs.leeds.ac.uk/systems/arc4.html#standard-nodes)
+  - [ARC4](../systems/arc4.html#standard-nodes)
     - 149 standard nodes, each with 40 cores
     - 2 high-memory nodes, each with 40 cores
 - Cloud computing
@@ -53,10 +53,10 @@ This guide asks a range of questions to consider when deciding which platform to
 - Buy a local laptop / workstation with a GPU
   - [Purchase form](https://it.leeds.ac.uk/it?id=sc_cat_item&sys_id=a649379c0f2f9b40a82247ece1050e25)
 - HPC (multiple / more powerful GPUs)
-  - [ARC3](https://arcdocs.leeds.ac.uk/systems/arc3.html#gpgpu-nodes)
+  - [ARC3](../systems/arc3.html#gpgpu-nodes)
     - 2 x [general purpose GPU](https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_processing_units) nodes, each with 2 x [NVIDIA Tesla K80](https://www.nvidia.com/en-gb/data-center/tesla-k80/)
     - 6 x [general purpose GPU](https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_processing_units) nodes, each with 4 x [NVIDIA Tesla P100](https://www.nvidia.com/en-gb/data-center/tesla-p100/)
-  - [ARC4](https://arcdocs.leeds.ac.uk/systems/arc4.html#gpgpu-nodes)
+  - [ARC4](../systems/arc4.html#gpgpu-nodes)
     - 3 x [general purpose GPU](https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_processing_units) nodes, each with 4 x [NVIDIA Tesla V100](https://www.nvidia.com/en-gb/data-center/tesla-v100/)
   - [Bede](https://bede-documentation.readthedocs.io/en/latest/hardware/index.html)
     - 2 x login GPU nodes each with 4 x [NVIDIA Tesla V100](https://www.nvidia.com/en-gb/data-center/tesla-v100/)
@@ -104,7 +104,7 @@ This guide asks a range of questions to consider when deciding which platform to
 
 ### How can I get an account on ARC3/4?
 
-- [Request an account on ARC](https://arcdocs.leeds.ac.uk/getting_started/request_hpc_acct.html)
+- [Request an account on ARC](../getting_started/request_hpc_acct)
 
 ### How can I get an account on Bede?
 

--- a/book/usage/advanced.md
+++ b/book/usage/advanced.md
@@ -80,4 +80,4 @@ $ qsub -hold_jid <jobname> job2.sh
 ```
 
 If you give several jobs the same name, then the job will be held until all the named jobs have been completed.
-See [Batch jobs](https://arcdocs.leeds.ac.uk/usage/batchjob.html?#list-of-sge-options) for more details on `hold_jid`.
+See [Batch jobs](./batchjob.html#list-of-sge-options) for more details on `hold_jid`.


### PR DESCRIPTION
There were a pile of hardcoded references to the arcdocs site, that have been
corrected to internal references.