### PR TITLE
adding steps for setting up python stata integration

### DIFF
--- a/book/software/applications/stata.md
+++ b/book/software/applications/stata.md
@@ -108,3 +108,96 @@ The job can then be submitted to the queuing system using the command:
 
 For more details on options used above and some of the other options
 available please look at the page on [Batch jobs](../../usage/batchjob).
+
+## Using Stata Python integration
+
+Stata allows for integration of Python within a Stata session. 
+From Stata 16 onwards it is possible to use Python from within Stata allowing you to embed and execute python code directly.
+
+For this to work Stata needs to be able to find an installation of Python on your system.
+On ARC4, Stata defaults to using the system Python 2.7 installation, which is not recommended.
+
+We recommend taking the following steps to allow Stata to use the [Anaconda Python 3 distribution](../compilers/anaconda) that is installed on ARC4.
+
+First, create a new Conda environment using the Conda package manager tool, within which you can install your preferred python version. 
+Creating a [new Conda environment](../compilers/anaconda#creating-custom-environments) allows you to separate the dependencies required for your Stata Python integration from any other Python dependencies you may have.
+
+```bash
+$ module add test anaconda stata/16
+
+$ conda create -n statapy python=3.10
+
+$ source activate statapy
+```
+
+Having activate our `statapy` environment we can now install any Python packages we require using `pip` or `conda`.
+
+Next, we need to configure our Stata session to use the Conda-installed version of Python.
+To do this we need to set two settings in Stata `python_exec` and `python_userpath`, you can view these settings directly within Stata by running `python query`.
+
+```stata
+. python query
+-------------------------------------------------------------------------------
+    Python Settings
+      set python_exec      /usr/bin/python
+      set python_userpath
+
+    Python system information
+      initialized          no
+      version              2.7.5
+      architecture         64-bit
+      library path         /usr/lib64/python2.7/config/libpython2.7.so
+```
+
+Here you can see the default setting uses the system installation of Python 2.7. 
+We can change this with the following steps:
+
+1. Find out the absolute path to your Conda-installed python executable
+
+    The simplest way to do this is to activate your Conda environment and run `which python` in the shell.
+    This should return a path location to your Conda-installed Python.
+
+    To find the correct path for `python_userpath` you will need to identify the location of `site-packages` in your Conda environment.
+    You can find this out by running ` python -c 'import sys; print(sys.path);'` in the shell. 
+    This will return for you a list of entries one of which will have a format of 
+    `/home/home01/arcuser/.conda/envs/ENV_NAME/lib/PY_VERSION/site-packages`
+    Where `ENV_NAME` is the name of your Conda environment and `PY_VERSION` is the version of python you installed.
+
+2. Use the path from step 1. to set the `python_exec` and `python_userpath` settings in Stata
+
+    In the example below the paths are specified for the `arcuser`, you will need to use the path provided by `which python`
+    which will include the path to your /home directory.
+
+    When setting `python_userpath` you should use the `site-package` path you identified in step 1.
+
+    You can set these settings with the following commands, using example paths below:
+
+    ```stata
+    . set python_exec /home/home01/arcuser/.conda/envs/statapy/bin/python, permanently
+    (python_exec preference recorded)
+
+    . set python_userpath /home/home01/arcuser/.conda/envs/statapy/lib/python3.10/site-packages, permanently
+    (python_userpath preference recorded)
+    ```
+
+This will set these changes to the Python settings permanently for your user on ARC4, so that you do not have to change these settings in the future.
+
+You can confirm these changes are in place by running `python query` in the Stata console again.
+
+```stata
+. python query
+-------------------------------------------------------------------------------
+    Python Settings
+      set python_exec      /home/home01/arcuser/.conda/envs/statapy/bin/python
+      set python_userpath  /home/home01/arcuser/.conda/envs/statapy/lib/python3.10/site-packages
+
+    Python system information
+      initialized          no
+      version              3.10.4
+      architecture         64-bit
+      library path         /home/home01/arcuser/.conda/envs/statapy/lib/libpython
+> 3.10m.so
+
+```
+
+Once these settings are configured you will be able to use Python from within Stata on ARC4.

--- a/book/software/applications/stata.md
+++ b/book/software/applications/stata.md
@@ -112,14 +112,14 @@ available please look at the page on [Batch jobs](../../usage/batchjob).
 ## Using Stata Python integration
 
 Stata allows for integration of Python within a Stata session. 
-From Stata 16 onwards it is possible to use Python from within Stata allowing you to embed and execute python code directly.
+From Stata 16 onwards it is possible to use Python from within Stata allowing you to embed and execute Python code directly.
 
 For this to work Stata needs to be able to find an installation of Python on your system.
 On ARC4, Stata defaults to using the system Python 2.7 installation, which is not recommended.
 
 We recommend taking the following steps to allow Stata to use the [Anaconda Python 3 distribution](../compilers/anaconda) that is installed on ARC4.
 
-First, create a new Conda environment using the Conda package manager tool, within which you can install your preferred python version. 
+First, create a new Conda environment using the Conda package manager tool, within which you can install your preferred Python version. 
 Creating a [new Conda environment](../compilers/anaconda#creating-custom-environments) allows you to separate the dependencies required for your Stata Python integration from any other Python dependencies you may have.
 
 ```bash
@@ -152,7 +152,7 @@ To do this we need to set two settings in Stata `python_exec` and `python_userpa
 Here you can see the default setting uses the system installation of Python 2.7. 
 We can change this with the following steps:
 
-1. Find out the absolute path to your Conda-installed python executable
+1. Find out the absolute path to your Conda-installed `python` executable
 
     The simplest way to do this is to activate your Conda environment and run `which python` in the shell.
     This should return a path location to your Conda-installed Python.
@@ -161,7 +161,7 @@ We can change this with the following steps:
     You can find this out by running ` python -c 'import sys; print(sys.path);'` in the shell. 
     This will return for you a list of entries one of which will have a format of 
     `/home/home01/arcuser/.conda/envs/ENV_NAME/lib/PY_VERSION/site-packages`
-    Where `ENV_NAME` is the name of your Conda environment and `PY_VERSION` is the version of python you installed.
+    Where `ENV_NAME` is the name of your Conda environment and `PY_VERSION` is the version of Python you installed.
 
 2. Use the path from step 1. to set the `python_exec` and `python_userpath` settings in Stata
 


### PR DESCRIPTION
This commit adds details of how to configure Stata/16 on ARC4 to use Conda-installed Python (preferred) on ARC4.