### PR TITLE
Add missing rsm entry to toc

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -37,6 +37,7 @@ sections:
       - file: software/applications/ansys/cfx
       - file: software/applications/ansys/fluent
       - file: software/applications/ansys/chemkin
+      - file: software/applications/ansys/rsm
     - file: software/applications/cesm
     - file: software/applications/comsol
     - file: software/applications/dl_poly


### PR DESCRIPTION
Previous documentation addition of mine missed updating the table of contents.