### PR TITLE
Update OpenFOAM documentation

### DIFF
--- a/book/software/applications/openfoam.md
+++ b/book/software/applications/openfoam.md
@@ -3,7 +3,9 @@
 OpenFOAM is an open-source set of C++ based command tools which can be used to perform Computational Fluid Dynamics simulations, it is entirely based inside the terminal and has no direct user interface. Results from the simulations can be viewed by running the command `paraFoam` to launch an external viewing application. This wiki will run through how to set up a case for running OpenFoam, as well as listing some of the basic tips on performing a simulation without error, primarily using the software available inside Mechanical Engineering.
 
 ```{note}
-For users of openfoam/v1906 you will need to execute the line `source $FOAM_SRC_FILE` before getting access to OpenFoam command line executeables.
+Versions older than v1906 may behaves slightly differently, such as not requiring `source $FOAM_SRC_FILE` but use of these versions is not covered by this documentation.  Usage described in this document assumes you're using v1906 on ARC4, and may require some adjustment if using other versions, or using ARC3.
+
+It also assumes you're using the default module environment, and haven't altered compilers being used.  If you have, please adjust accordingly.
 ```
 
 ## Overview of case setup
@@ -230,17 +232,17 @@ OpenFOAM is a free, open source CFD software package; this does not require a li
 The openfoam installed on our systems is compiled with a gnu compiler rather than the intel one which is the default in your environment. Before you can load the openfoam module you will need to switch compilers.
 
 ```bash
-$ module sw intel gnu/4.8.1
-$ module load openfoam
+$ module swap intel gnu/6.3.0
+$ module add openfoam/v1906
 ```
 
 The environment is not yet fully loaded. To check what you need to do you can run the command:
 
 ```bash
-$ module help openfoam
+$ module help openfoam/v1906
 ```
 
-Next run the following command to access the openFoam command line variables:
+For v1906, next run the following command to access the openFoam command line variables:
 
 ```bash
 $ source $FOAM_SRC_FILE
@@ -265,10 +267,10 @@ Sun Grid engine allows both interactive and batch jobs to be submitted during wh
 The following will launch paraFoam interactively, displaying the full GUI:
 
 ```bash
-$ qrsh -cwd -V -l h_rt= paraFoam
+$ qrsh -cwd -V -l h_rt=<hh:mm:ss> paraFoam
 ```
 
-In the above command, `<hh:mm:ss>` is the length of real-time the shell will exist for, `-cwd` indicated the current working directory and `-V` exports the the current environment.CHECK-code e.g. to run paraFoam for 1 hour:
+In the above command, `<hh:mm:ss>` is the length of real-time the shell will exist for, `-cwd` indicated the current working directory and `-V` exports the the current environment.  For example, to run paraFoam for 1 hour:
 
 ```bash
 $ qrsh -cwd -V -l h_rt=1:00:00 paraFoam
@@ -280,7 +282,7 @@ This will run paraFoam within the terminal from which it was launched.
 
 To run OpenFOAM in batch-mode you first need to setup your case.
 
-A script must then be created that will request resources from the queuing system and launch the desired OpenFOAM executables; script `runfoam.sh` :
+A script must then be created that will request resources from the queuing system and launch the desired OpenFOAM executables; script `runfoam.sh`:
 
 ```bash
 #!/bin/bash
@@ -289,7 +291,9 @@ A script must then be created that will request resources from the queuing syste
 # Set a 6 hour limit
 #$ -l h_rt=6:00:00
 # Load OpenFOAM module
-module add test openfoam
+module swap intel gnu/6.3.0
+module add openfoam/v1906
+source $FOAM_SRC_FILE
 # Run actual OpenFoam commands
 blockMesh
 icoFoam
@@ -308,20 +312,20 @@ If you've configured your OpenFOAM job to be solved in parallel, you need to sub
 ```bash
 #$ -l h_rt=00:10:00
 #$ -l h_vmem=2G
-#$ -l np=16
+#$ -l np=40
 #$ -cwd -V
-export MPI_BUFFER_SIZE=8192
-module purge
-module add bit/64 gnu openmpi test openfoam
-mpirun -np $NSLOTS interFoam -parallel
+module swap intel gnu/6.3.0
+module add openfoam/v1906
+source $FOAM_SRC_FILE
+mpirun interFoam -parallel
 ```
 
-This will request 16 cores and exclusive access to the nodes. This results in 1 node being allocated and 2GB memory per core.
+This will request 40 cores and exclusive access to the nodes. On ARC4, this results in a single node being allocated, with a full node's memory split between those 16 cores.
 
 If more memory per core is required, then reduce the number of processes per node to split the available memory netween those active processes. For example,
 
 ```bash
-#$ -l np=16,ppn=4
+#$ -l np=40,ppn=10
 ```
 
-Will give 16 cores as before, but this time with 4 processes per core and so 4 nodes overall. The available memory per node (32GB) is therefore allocated across 4 cores (ie. ppn=4) and so 8GB per node will be allocated.
+Will give 40 cores as before, but this time with 10 processes per node and so 4 nodes overall. The available memory per node is therefore allocated across four nodes rather than one and so four times the memory would be available per core compared to the previous example.

--- a/book/software/applications/openfoam.md
+++ b/book/software/applications/openfoam.md
@@ -3,7 +3,7 @@
 OpenFOAM is an open-source set of C++ based command tools which can be used to perform Computational Fluid Dynamics simulations, it is entirely based inside the terminal and has no direct user interface. Results from the simulations can be viewed by running the command `paraFoam` to launch an external viewing application. This wiki will run through how to set up a case for running OpenFoam, as well as listing some of the basic tips on performing a simulation without error, primarily using the software available inside Mechanical Engineering.
 
 ```{note}
-Versions older than v1906 may behaves slightly differently, such as not requiring `source $FOAM_SRC_FILE` but use of these versions is not covered by this documentation.  Usage described in this document assumes you're using v1906 on ARC4, and may require some adjustment if using other versions, or using ARC3.
+Versions older than v1906 may behave slightly differently, such as not requiring `source $FOAM_SRC_FILE` but use of these versions is not covered by this documentation.  Usage described in this document assumes you're using v1906 on ARC4, and may require some adjustment if using other versions, or using ARC3.
 
 It also assumes you're using the default module environment, and haven't altered compilers being used.  If you have, please adjust accordingly.
 ```


### PR DESCRIPTION
The previous documentation assumed you were running on a very old HPC, and using an old version of OpenFOAM. This adjusts it so that it's assuming v1906, and ARC4.