### PR TITLE
Updated notes on running Fluent

### DIFF
--- a/book/software/applications/ansys/fluent.md
+++ b/book/software/applications/ansys/fluent.md
@@ -100,13 +100,13 @@ There are three ways of launching Fluent to work in parallel:
 To launch an [interactive session](../../../usage/interactive) with high resource requirements, load the ansys module and type the following at the command prompt:
 
 ```bash
-$ qrsh -cwd -V -l h_rt=<hh:mm:ss> -l nodes=<nodes> fluent <dim> -rsh
+$ qrsh -cwd -V -l h_rt=<hh:mm:ss> -l nodes=<nodes> fluent <dim> -t <cores> -rsh
 ```
 
-In the above commands `hh:mm:ss` is the length of real-time the shell will exist for and `nodes` is the number of nodes requested. `dim` is the dimension/precision of the fluent process (e.g. 3ddp for 3-D double precision). E.g. the to launch fluent for 6 hours on 40 processors on ARC4:
+In the above commands `hh:mm:ss` is the length of real-time the shell will exist for and `nodes` is the number of nodes requested, and `cores` is the number of cores to use. `dim` is the dimension/precision of the fluent process (e.g. 3ddp for 3-D double precision). E.g. the to launch fluent for 6 hours on 40 processors on ARC4:
 
 ```bash
-$ qrsh -cwd -V -l h_rt=6:00:00 -l nodes=1 fluent 2d -rsh
+$ qrsh -cwd -V -l h_rt=6:00:00 -l nodes=1 fluent 2d -t 40 -rsh
 ```
 
 We'd not normally recommend running Fluent interactively on the HPC though, as you're almost always better running batch jobs.
@@ -146,7 +146,7 @@ Then a job submission script (`fluent_para.sh`) should be created, that requests
 module add ansys/2020R2
 export ANSYSLMD_LICENSE_FILE=<LICENSESTRING>
 #Launch the executable
-fluent -g -i test_para.jou 3ddp -rsh
+fluent -g -i test_para.jou 3ddp -t $NSLOTS -rsh
 ```
 
 In this case, the 3-dimensional, double precision module is launched on 40 processors. The `-g` option will suppress the GUI and `-i` specifies the name of the input journal file. The file can be submitted to the queue by typing:
@@ -173,7 +173,7 @@ Fluent supports the use of GPUs, although we've not currently seen significant b
 module add ansys/2020R2
 export ANSYSLMD_LICENSE_FILE=<LICENSESTRING>
 #Launch the executable
-fluent -g -i -gpgpu=1 test_para.jou 3ddp -rsh
+fluent -g -i -gpgpu=1 test_para.jou 3ddp -t $NSLOTS -rsh
 ```
 
 ## Running with old version of Fluent v15 or below
@@ -202,13 +202,13 @@ There are also known inefficiencies when running fluent on part nodes on ARC, wh
 #$ -cwd
 # Request three hours of runtime
 #$ -l h_rt=3:00:00
-# Run on 1 nodes (24 cores on ARC3, 40 cores on ARC4)
+# Run on 1 node (24 cores on ARC3, 40 cores on ARC4)
 #$ -l nodes=1
 # define license and load module
 module add ansys/2020R2
 export ANSYSLMD_LICENSE_FILE=<LICENSESTRING>
 #Launch the executable
-fluent -g -i test_para.jou 3ddp -rsh
+fluent -g -i test_para.jou 3ddp -t 40 -rsh
 ```
 
 You will wait slightly longer for a whole node than using the scattered allocation model (`-pe ib 40`), but your code is likely to run significantly faster.


### PR DESCRIPTION
Ansys 2022R1 seems to require you to enter -t $NSLOTS, else it has a license warning and only runs on 4 cores.

This addresses #148 