### PR TITLE
Add Apptainer section

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -76,6 +76,7 @@ sections:
     sections:
     - file: software/infrastructure/advisor.md
     - file: software/infrastructure/allinea.md
+    - file: software/infrastructure/apptainer.md
     - file: software/infrastructure/arm-forge.md
     - file: software/infrastructure/bazel.md
     - file: software/infrastructure/cmake.md

--- a/book/software/infrastructure/apptainer.md
+++ b/book/software/infrastructure/apptainer.md
@@ -1,0 +1,31 @@
+# Apptainer
+
+Apptainer is a free, cross-platform and open-source computer program that
+performs operating-system-level virtualization also known as containerization.
+You can read more about at the [Apptainer website](https://apptainer.org/).
+
+There are additional pointers on Apptainer within the Container section of
+[HPC2](https://arctraining.github.io/hpc2-software/course/containers.html)
+
+## The Apptainer module on the HPC
+
+The Apptainer module can be loaded into your environment with the following
+command:
+
+```bash
+$ module add apptainer
+```
+
+The apptainer module is available on ARC4:
+
+```{list-table}
+:header-rows: 1
+:widths: 10 20 10
+
+* - System
+  - Version
+  - Command
+* - ARC4
+  - Apptainer 1.1.6
+  - `module add apptainer/1.1.6`
+```

--- a/book/software/infrastructure/singularity.md
+++ b/book/software/infrastructure/singularity.md
@@ -2,6 +2,8 @@
 
 Singularity is a free, cross-platform and open-source computer program that performs operating-system-level virtualization also known as containerization. You can read more about at the [Singularity website](https://singularity.lbl.gov/).
 
+It has been superceded on ARC4 by [Apptainer](apptainer).
+
 ## The Singularity module on the HPC
 
 The Singularity module can be loaded into your environment with the following command:


### PR DESCRIPTION
Addresses #68 give or take, to add to the existing flimsy singularity section.  Adds a new apptainer sections, and references the container section of the HPC2 content for more information.