### PR TITLE
Fix for anaconda

### DIFF
--- a/book/software/compilers/anaconda.md
+++ b/book/software/compilers/anaconda.md
@@ -103,6 +103,9 @@ To avoid this you can use the following steps to move your `.conda` directory to
 ```bash
 $ cd ~
 
+# delete symlink, if already present
+$ rm -f .conda
+
 # create these directories if they don't already exist
 $ mkdir -p .conda /nobackup/$USER
 


### PR DESCRIPTION
This removes any symlink already present, avoiding problems for people who follow these instructions twice for ARC3 and ARC4.