### PR TITLE
Change to install jupyter-book via conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
 name: arcdocs-jb
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - python=3.9
   - jinja2=3.0.3
   - pip=20
   - pre-commit=2.20.0
-  - pip:
-    - jupyter-book==0.13.1
+  - jupyter-book==0.13.1


### PR DESCRIPTION
I'm hitting a big spin within pip on installing jupyter-book both on my Linux machine and within the GitHub Action, so let's just swap it out with the conda version.  This is the same as the fix applied to HPC2.