### PR TITLE
A number of minor fixes

### DIFF
--- a/book/getting_started/file_transfer/rclone.md
+++ b/book/getting_started/file_transfer/rclone.md
@@ -226,7 +226,7 @@ Once you've set up the remote drive, you don't need to do it again. To list file
 $ rclone ls onedrive:[directory]
 ```
 
-To copy file <file> from directory [directory] in OneDrive to your current local directory:
+To copy file `<file>` from directory [directory] in OneDrive to your current local directory:
 
 ```bash
 $ rclone copy onedrive:[path]/<file> .
@@ -279,7 +279,7 @@ Get help on rclone:
 ```
 $ rclone help
 ```
-<!-- 
+<!--
 Usage:
   rclone [flags]
   rclone [command]

--- a/book/getting_started/logon/logon-off-campus.md
+++ b/book/getting_started/logon/logon-off-campus.md
@@ -57,7 +57,7 @@ $ ssh arc4.leeds.ac.uk
 $ ssh arc3.leeds.ac.uk
 ```
 
-You'll be prompted to login to remote-access.leeds.ac.uk first and may be presented with an interactive login that looks like below:
+You'll be prompted to login to `remote-access.leeds.ac.uk` first and may be presented with an interactive login that looks like below:
 
 ```bash
 $ ssh arc4.leeds.ac.uk

--- a/book/getting_started/logon/logon-off-campus.md
+++ b/book/getting_started/logon/logon-off-campus.md
@@ -57,7 +57,7 @@ $ ssh arc4.leeds.ac.uk
 $ ssh arc3.leeds.ac.uk
 ```
 
-You'll be prompted to login to `remote-access.leeds.ac.uk` first and may be presented with an interactive login that looks like below:
+You'll be prompted to login to remote-access\\.leeds.ac.uk first and may be presented with an interactive login that looks like below:
 
 ```bash
 $ ssh arc4.leeds.ac.uk
@@ -224,7 +224,7 @@ In order to successfully connect off-campus you are required to adjust some sett
 
 | 10. Type the contents of the file as follows where `exuser` is your university username                                                                                                                                                             |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <pre id="codecell0"> Host \*.leeds.ac.uk !remote-access.leeds.ac.uk <br> ProxyJump exuser@remote-access.leeds.ac.uk <br> User exuser <br> <br> Host remote-access.leeds.ac.uk <br> PreferredAuthentications publickey,keyboard-interactive </pre> |
+| <pre id="codecell0"> Host \*.leeds.ac.uk !remote-access\\.leeds.ac.uk <br> ProxyJump exuser\@remote-access.leeds.ac.uk <br> User exuser <br> <br> Host remote-access\\.leeds.ac.uk <br> PreferredAuthentications publickey,keyboard-interactive </pre> |
 | ![This takes you to the MobaXTerm terminal view](../../assets/img/logon/offcampus/mobaSSH10.png)                                                                                                                                                      |
 
 | 11. Once complete go to File > Save As                                                |

--- a/book/getting_started/x2go.md
+++ b/book/getting_started/x2go.md
@@ -35,7 +35,7 @@ places on the window where you need to provide information on the image below.
 The information needs is:
 
 1.  The name of the session -- I have used arc3
-2.  The name of the host which is arc3.leeds.ac.uk
+2.  The name of the host which is arc3\\.leeds.ac.uk
 3.  Your userid
 4.  Select the option "Published Applications"
 
@@ -76,8 +76,8 @@ type:
 Normally when you login you are allocated login1 or login2 randomly. If you
 wish to restart a X2GO session then you need to login explicitly to the login
 node that you paused the session on. If you want to use this feature then you
-will need to explicitly login to login1.arc3.leeds.ac.uk or
-login2.arc3.leeds.ac.uk.
+will need to explicitly login to login1\\.arc3.leeds.ac.uk or
+login2\\.arc3.leeds.ac.uk.
 
 We have not currently tested all the modes that you can login with. The shells
 available with the way I have described are xterm or MATE Terminal.

--- a/book/software/applications/ansys/lsdyna.md
+++ b/book/software/applications/ansys/lsdyna.md
@@ -9,7 +9,7 @@ More information about LS-DYNA can be found on the [Ansys Website](https://www.a
 ## Running LS-DYNA
 
 ```{note}
-More details about using Ansys for the first time and setting license server details can be found on the [Ansys page](../ansys.html#Additional-Step-for-Using-Ansys-the-First-Time).
+More details about using Ansys for the first time and setting license server details can be found on the [Ansys page](ansys:additional-steps).
 ```
 
 ### Batch job examples

--- a/book/software/applications/ansys/rsm.md
+++ b/book/software/applications/ansys/rsm.md
@@ -87,7 +87,7 @@ Name: ARC4
 \
 HPC type: UGE (SGE)
 \
-Submit host: arc4.leeds.ac.uk
+Submit host: arc4\\.leeds.ac.uk
 \
 Shared memory parallel: smp
 \

--- a/book/software/applications/ansys/rsm.md
+++ b/book/software/applications/ansys/rsm.md
@@ -43,8 +43,11 @@ leaves it running in the taskbar).
 ### Test this with putty
 
 Run putty
+\
 Enter `arc4.leeds.ac.uk` as the host
+\
 Accept the host key (you can verify this against the fingerprint here)
+\
 Enter your username
 
 If all has gone well, this connects using your key, and doesn't prompt for a
@@ -81,14 +84,21 @@ Click the Add HPC Resource button, top left.
 #### HPC Resource tab
 
 Name: ARC4
+\
 HPC type: UGE (SGE)
+\
 Submit host: arc4.leeds.ac.uk
+\
 Shared memory parallel: smp
+\
 Distributed parallel: ib
+\
 UGE Job submission arguments: `-l h_rt=48:0:0`
+\
 Deselect Use SSH protocol for inter and intra-node communication (Linux only)
 
 Select Use SSH or custom communication to the submit host
+\
 Enter you username for Account name
 
 Click Apply
@@ -96,6 +106,7 @@ Click Apply
 #### File Management tab
 
 Select External mechanism for file transfer (SCP via SSH)
+\
 Set the Staging directory path to where you want to store these files on ARC.
 For example, `/nobackup/alice/ansys-rsm`
 
@@ -107,6 +118,7 @@ and create this directory at this point.
 #### Queues
 
 Click Import/Refresh HPC queues.
+\
 This should then show you all the queues it has found on ARC4.  Deselect the
 one it has selected, and select the queue you want to use.  If you're not use,
 use 40core-192G.q.

--- a/book/software/applications/gaussian.md
+++ b/book/software/applications/gaussian.md
@@ -180,7 +180,7 @@ The above script can be submitted to the batch queues through the qsub command:
 
     $ qsub
 
-When it runs, it creates the input file, formaldehyde.com, and then runs the
+When it runs, it creates the input file, formaldehyde\\.com, and then runs the
 job, such that the .log file and .chk file are saved in the current working
 directory. The .rwf files are written to local disk on the compute node where
 the job runs, and deleted upon completion of the job.

--- a/book/software/applications/gaussian.md
+++ b/book/software/applications/gaussian.md
@@ -107,7 +107,7 @@ A sample script follows:
     #$ -l h_vmem=1G
     module add gaussian
     export GAUSS_SCRDIR=$TMPDIR
-    g09 formaldeyhde.co
+    g09 formaldeyhde.com
 
 This will request 1 hour of runtime on a single processor with 1GB memory, this
 is the default amount of memory so the line `#$ -l h_vmem=1G` does not really

--- a/book/software/applications/gaussian.md
+++ b/book/software/applications/gaussian.md
@@ -135,17 +135,17 @@ A sample script is:
     export OMP_NUM_THREADS=1
     g09 formaldeyhde.com
 
-This will request \<np\> processors, each with 1GB memory.
+This will request `<np>` processors, each with 1GB memory.
 
 On ARC3 the maximum size of job is 24 cores and a total of 128GB on a standard
 node or 768GB on a high memory node.  On ARC4 this increases to 40 cores and a
 total of 192GB on a standard node or 768GB on a high memory node.
 
-To instruct Gaussian to start \<np\> threads, `%NProcShared=\<np\>` should be set
+To instruct Gaussian to start `<np>` threads, `%NProcShared=<np>` should be set
 in the Gaussian input file.
 
 It is possible to combine the submission script and input file into a single
-script so that the np in the submission script always matches `%NProcShared=\<np\>`
+script so that the np in the submission script always matches `%NProcShared=<np>`
 in the Gaussian input file:
 
     #$ -cwd

--- a/book/software/applications/idl.md
+++ b/book/software/applications/idl.md
@@ -62,4 +62,4 @@ If the resources are not available at the point the scheduler tries to allocate 
 You may find you have to submit the request a few times until it is successful.
 ```
 
-You can read more about interactive sessions on HPC in the [Useage section](../../usage/interactive).
+You can read more about interactive sessions on HPC in the [Usage section](../../usage/interactive).

--- a/book/software/applications/openfoam.md
+++ b/book/software/applications/openfoam.md
@@ -85,7 +85,7 @@ There is one final option which may be relevant when moving into compiling your 
 libs ("libs.so")
 ```
 
-where "relevant extension" leads to the correct library for the application e.g. libsuserRAS.so, for your own compiled RAS turbulence models.
+where "relevant extension" leads to the correct library for the application e.g. libsuserRAS\\.so, for your own compiled RAS turbulence models.
 
 ## RAS/LES properties and transportDict
 

--- a/book/software/applications/visit.md
+++ b/book/software/applications/visit.md
@@ -52,9 +52,9 @@ Or, where using more than one cpu is useful, to launch visit in parallel
     $ module load visit
     $ qrsh -cwd -V -l h_rt=<hh:mm:ss> -l h_vmem=<vmem> -pe ib <num> visit -np <num>
 
-In the above commands, <hh:mm:ss> is the length of real time the program
-will be run for, <vmem> is the amount of memory required per core (e.g.
-"1G" for 1 GB RAM), and <num> is the number of cores required (please note
+In the above commands, `<hh:mm:ss>` is the length of real time the program
+will be run for, `<vmem>` is the amount of memory required per core (e.g.
+"1G" for 1 GB RAM), and `<num>` is the number of cores required (please note
 it appears twice in the command).
 
 ## Running VisIT on your workstation, offload storage and processing to the ARC systems

--- a/book/usage/gpgpu.md
+++ b/book/usage/gpgpu.md
@@ -42,7 +42,7 @@ To request K80 GPU resource you should use the flag:
 #$ -l coproc_k80=<cards_per_compute_node>
 ```
 
-Where <cards_per_compute_node> should be set to 1 or 2.
+Where `<cards_per_compute_node>` should be set to 1 or 2.
 
 ```{list-table}
 :header-rows: 1
@@ -64,7 +64,7 @@ To request P100 GPU resource you should use the flag:
 #$ -l coproc_p100=<cards_per_compute_node>
 ```
 
-Where <cards_per_compute_node> should be set to 1, 2, 3 or 4.
+Where `<cards_per_compute_node>` should be set to 1, 2, 3 or 4.
 
 ```{list-table}
 :header-rows: 1
@@ -98,7 +98,7 @@ To request V100 GPU resource you should use the flag:
 #$ -l coproc_v100=<cards_per_compute_node>
 ```
 
-Where <cards_per_compute_node> should be set to 1, 2, 3 or 4.
+Where `<cards_per_compute_node>` should be set to 1, 2, 3 or 4.
 
 ```{list-table}
 :header-rows: 1


### PR DESCRIPTION
This fixes a number of minor issues, some of which may have been caused by the Jupyter Book update, and some of which likely predated it.

A number of automatic links have been escaped, as MyST was auto generating hyperlinks for things that looked like domain names, even though they shouldn't have had.

In other places we had slightly over enthusiastic escaping of things, leading to backslashes being rendered.