### PR TITLE
Alternate job submission for small Fluent jobs

### DIFF
--- a/book/software/applications/ansys/fluent.md
+++ b/book/software/applications/ansys/fluent.md
@@ -157,6 +157,29 @@ $ qsub fluent_para.sh
 
 The job will be run once the requested resources become available.
 
+### Smaller parallel jobs
+
+If you want to run on multiple cores but use less than a whole node, it's
+recommended that you use the smp parallel environment, and use a slightly
+different fluent command:
+
+```bash
+#!/bin/bash
+# use current working directory
+#$ -cwd
+# Request three hours of runtime
+#$ -l h_rt=3:00:00
+# Run on 8 cores
+#$ -pem smp 8
+# Request 4Gbytes per core
+#$ -l h_vmem=4G
+# define license and load module
+module add ansys/2020R2
+export ANSYSLMD_LICENSE_FILE=<LICENSESTRING>
+#Launch the executable
+fluent -g -i test_para.jou 3ddp
+```
+
 ### GPU execution using the batch queues
 
 Fluent supports the use of GPUs, although we've not currently seen significant benefit from doing so on ARC.  To submit a GPU job:


### PR DESCRIPTION
It's been found that the current advice for whole nodes doesn't work right if you decide to run on less, so let's just include an example that shows how you can run smaller jobs.