### PR TITLE
Added note to conda-container docs

### DIFF
--- a/book/usage/conda-containers.md
+++ b/book/usage/conda-containers.md
@@ -2,7 +2,9 @@
 
 This is a set of instructions for creating and using a conda environment within
 a container.  This can be used on the HPC or elsewhere.  We recommend
-[Apptainer](../software/infrastructure/apptainer)
+[Apptainer](../software/infrastructure/apptainer).  This is tested as working
+on ARC4 only, although containers built this way on ARC4 should also work on
+ARC3.
 
 ## Why you want to use containers for Conda environments
 


### PR DESCRIPTION
Since ARC3 is now very much legacy, it doesn't support newer features required to make all this work.  It is only known to work on ARC4.