### PR TITLE
Update Rclone docs

### DIFF
--- a/book/getting_started/file_transfer/rclone.md
+++ b/book/getting_started/file_transfer/rclone.md
@@ -35,19 +35,19 @@ Next enter the name you want to use for the new remote connection (I use onedriv
 name> onedrive
 ```
 
-After pressing `Enter`, a list of supported storage types is shown. You should select the Microsoft OneDrive option (currently 19 but may change in the future):
+After pressing `Enter`, a list of supported storage types is shown. You should select the Microsoft OneDrive option (the output below is the current version, but will change in the future so please check the number value of OneDrive):
 
 ```bash
 Type of storage to configure.
 Enter a string value. Press Enter for the default ("").
 Choose a number from below, or type in your own value
- 1 / A stackable unification remote, which can appear to merge the contents of several remotes
-   \ "union"
- 2 / Alias for a existing remote
+ 1 / 1Fichier
+   \ "fichier"
+ 2 / Alias for an existing remote
    \ "alias"
  3 / Amazon Drive
    \ "amazon cloud drive"
- 4 / Amazon S3 Compliant Storage Provider (AWS, Alibaba, Ceph, Digital Ocean, Dreamhost, IBM COS, Minio, etc)
+ 4 / Amazon S3 Compliant Storage Providers including AWS, Alibaba, Ceph, Digital Ocean, Dreamhost, IBM COS, Minio, and Tencent COS
    \ "s3"
  5 / Backblaze B2
    \ "b2"
@@ -55,62 +55,106 @@ Choose a number from below, or type in your own value
    \ "box"
  7 / Cache a remote
    \ "cache"
- 8 / Dropbox
+ 8 / Citrix Sharefile
+   \ "sharefile"
+ 9 / Compress a remote
+   \ "compress"
+10 / Dropbox
    \ "dropbox"
- 9 / Encrypt/Decrypt a remote
+11 / Encrypt/Decrypt a remote
    \ "crypt"
-10 / FTP Connection
+12 / Enterprise File Fabric
+   \ "filefabric"
+13 / FTP Connection
    \ "ftp"
-11 / Google Cloud Storage (this is not Google Drive)
+14 / Google Cloud Storage (this is not Google Drive)
    \ "google cloud storage"
-12 / Google Drive
+15 / Google Drive
    \ "drive"
-13 / Hubic
+16 / Google Photos
+   \ "google photos"
+17 / Hadoop distributed file system
+   \ "hdfs"
+18 / Hubic
    \ "hubic"
-14 / JottaCloud
+19 / In memory object storage system.
+   \ "memory"
+20 / Jottacloud
    \ "jottacloud"
-15 / Koofr
+21 / Koofr
    \ "koofr"
-16 / Local Disk
+22 / Local Disk
    \ "local"
-17 / Mega
+23 / Mail.ru Cloud
+   \ "mailru"
+24 / Mega
    \ "mega"
-18 / Microsoft Azure Blob Storage
+25 / Microsoft Azure Blob Storage
    \ "azureblob"
-19 / Microsoft OneDrive
+26 / Microsoft OneDrive
    \ "onedrive"
-20 / OpenDrive
+27 / OpenDrive
    \ "opendrive"
-21 / Openstack Swift (Rackspace Cloud Files, Memset Memstore, OVH)
+28 / OpenStack Swift (Rackspace Cloud Files, Memset Memstore, OVH)
    \ "swift"
-22 / Pcloud
+29 / Pcloud
    \ "pcloud"
-23 / QingCloud Object Storage
+30 / Put.io
+   \ "putio"
+31 / QingCloud Object Storage
    \ "qingstor"
-24 / SSH/SFTP Connection
+32 / SSH/SFTP Connection
    \ "sftp"
-25 / Webdav
+33 / Sugarsync
+   \ "sugarsync"
+34 / Tardigrade Decentralized Cloud Storage
+   \ "tardigrade"
+35 / Transparently chunk/split large files
+   \ "chunker"
+36 / Union merges the contents of several upstream fs
+   \ "union"
+37 / Webdav
    \ "webdav"
-26 / Yandex Disk
+38 / Yandex Disk
    \ "yandex"
-27 / http Connection
+39 / Zoho
+   \ "zoho"
+40 / http Connection
    \ "http"
-Storage> 19
+41 / premiumize.me
+   \ "premiumizeme"
+42 / seafile
+   \ "seafile"
+Storage> 26
 ```
 
-For the next 2 steps, just accept the defaults by pressing `Enter` twice:
+For the next 3 steps, just accept the defaults by pressing `Enter` twice:
 
 ```bash
 ** See help for onedrive backend at: https://rclone.org/onedrive/ **
 
-Microsoft App Client Id
+OAuth Client Id
 Leave blank normally.
 Enter a string value. Press Enter for the default ("").
 client_id>
-Microsoft App Client Secret
+
+OAuth Client Secret
 Leave blank normally.
 Enter a string value. Press Enter for the default ("").
 client_secret>
+
+Choose national cloud region for OneDrive.
+Enter a string value. Press Enter for the default ("global").
+Choose a number from below, or type in your own value
+ 1 / Microsoft Cloud Global
+   \ "global"
+ 2 / Microsoft Cloud for US Government
+   \ "us"
+ 3 / Microsoft Cloud Germany
+   \ "de"
+ 4 / Azure and Office 365 operated by 21Vianet in China
+   \ "cn"
+region>
 ```
 
 Unless you need to edit the advanced configuration, choose `n`

--- a/book/getting_started/file_transfer/rclone.md
+++ b/book/getting_started/file_transfer/rclone.md
@@ -260,7 +260,7 @@ q) Quit config
 e/n/d/r/c/s/q> q
 ```
 
-### If remotely opening the browser does not work
+### If launching the remote browser does not work
 
 Forwarding the Firefox browser in order to authenticate Microsoft OneDrive can be a slow process, but will usually load when given time. If this does not work however, you can follow the remote configuration suggestions given [here](https://rclone.org/remote_setup/). If you have rclone installed on your local pc you can select `n` in response to this prompt and configure it locally as detailed in the [rclone documentation](https://rclone.org/remote_setup/).
 

--- a/book/getting_started/file_transfer/rclone.md
+++ b/book/getting_started/file_transfer/rclone.md
@@ -260,6 +260,21 @@ q) Quit config
 e/n/d/r/c/s/q> q
 ```
 
+### If remotely opening the browser does not work
+
+Forwarding the Firefox browser in order to authenticate Microsoft OneDrive can be a slow process, but will usually load when given time. If this does not work however, you can follow the remote configuration suggestions given [here](https://rclone.org/remote_setup/). If you have rclone installed on your local pc you can select `n` in response to this prompt and configure it locally as detailed in the [rclone documentation](https://rclone.org/remote_setup/).
+
+```
+Remote config
+Use auto config?
+ * Say Y if not sure
+ * Say N if you are working on a remote or headless machine
+y) Yes (default)
+n) No
+y/n> n
+```
+Alternatively, from Linux, Mac or MobaXterm you can use ssh tunelling to authorise your account by [following the instructions here](http://127.0.0.1:53682/).
+
 ## Using rclone on HPC
 
 One of our users has written a small utility to make it easier to copy multiple files from OneDrive onto ARC. If you don't fancy the command line options below, you might want to take a look at: [Copy multiple files from OneDrive to ARC](https://foqueiroz.github.io/web/public/arc/index.html)

--- a/book/getting_started/file_transfer/rclone.md
+++ b/book/getting_started/file_transfer/rclone.md
@@ -273,7 +273,19 @@ y) Yes (default)
 n) No
 y/n> n
 ```
-Alternatively, from Linux, Mac or MobaXterm you can use ssh tunelling to authorise your account by [following the instructions here](http://127.0.0.1:53682/).
+Alternatively, from Linux, Mac or MobaXterm you can use ssh tunelling to authorise your account by [following the instructions here](http://127.0.0.1:53682/). First, configure your connection and set up a proxy jump on [Linux or Mac](https://arcdocs.leeds.ac.uk/getting_started/logon/logon-off-campus.html#connecting-from-linux-macos-systems) or on Windows through [MobaXterm](https://arcdocs.leeds.ac.uk/getting_started/logon/logon-off-campus.html#using-the-mobaxterm-terminal). Then, connect to ARC4 from your terminal (or from the MobaXterm local terminal) without graphics forwarding, with your arc4 username:
+
+```
+ssh <<YOUR USERNAME HERE>>@arc4.leeds.ac.uk
+```
+and follow the required password and Duo Security prompts. Make note of your login node. Then, launch another local
+terminal, and run (with username and login node changed to relevant values):
+
+```
+ssh -N -f -L localhost:53682:localhost:53682 <<YOUR USERNAME HERE>>@<<LOGIN NODE HERE>>.arc4.leeds.ac.uk
+```
+Again, you will be prompted for credentials to log in.
+Back in your Arc4 session, run rclone config as normal, and choose `y` when prompted re. automatic configuration. Copy and paste the URL into your local machine's browser. You should be able to access the authentication website from here. If for some reason a remote firefox browser pops up (automatic X-forwarding on MobaXterm, for example), close this. You can continue the rest of the rclone config from the terminal once authentication has been completed.
 
 ## Using rclone on HPC
 


### PR DESCRIPTION
Updating rclone options to make them (temporarily) in-date. Also adding ssh tunelling option for cases where the forwarding of Firefox is too slow/gets stuck for authentication.