### PR TITLE
Tweak conda containers instructions, to avoid lockfiles

### DIFF
--- a/book/usage/conda-containers.md
+++ b/book/usage/conda-containers.md
@@ -52,6 +52,7 @@ From: mambaorg/micromamba
 %post
     micromamba create -q -y -f environment.yml -p /opt/conda-env
     micromamba clean -aqy
+    micromamba config set --system use_lockfiles false
 
 %runscript
     micromamba run -p /opt/conda-env "$@"


### PR DESCRIPTION
Under certain circumstances you can find that there's an issue with lockfiles when using micromamba on the cluster, that likely causes unnecessary delays.

This sets a container default of not using lockfiles, that can still be overridden by the user if required.